### PR TITLE
Add scaffold for digital automation system

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,65 @@
+# Digital Ecosystem Scaffold for Small Construction Company
+
+This scaffold demonstrates how receipts, fuel logs, quotes, and dashboards
+can be digitised.
+
+## Folder Structure
+
+```
+├── docs/               # Design docs
+├── excel_templates/    # CSV templates for fuel logs and quotes
+├── src/
+│   ├── ocr/            # Receipt OCR and job assignment scripts
+│   └── dashboard/      # Flask web dashboard
+```
+
+## Tools Overview
+
+* **OCR** – `src/ocr/receipt_ocr.py` uses [pytesseract] to convert scanned
+  receipts to text and outputs JSON. `job_assigner.py` helps tag each line
+  item with a job ID.
+* **Fuel Log** – `excel_templates/fuel_log_template.csv` is a structured
+  template that can be opened in Excel or Google Sheets for entering fuel
+  expenses.
+* **Quote Generator** – `excel_templates/quote_template.csv` acts as a base
+  for creating job quotes. More advanced automation can read product prices
+  from a database and export PDFs.
+* **Dashboard** – `src/dashboard/app.py` is a minimal Flask app. It allows
+  receipt uploads and lists stored files. This can be extended with cost
+  breakdowns and project summaries.
+
+## Sample Automation Snippets
+
+### OCR Processing
+```python
+from pathlib import Path
+from PIL import Image
+import pytesseract
+
+text = pytesseract.image_to_string(Image.open('receipt.jpg'))
+Path('receipt.txt').write_text(text)
+```
+
+### Assigning Jobs per Line Item
+```python
+import csv
+rows = list(csv.DictReader(open('receipt.csv')))
+for row in rows:
+    row['job_id'] = input(f"Job for {row['item']}? ")
+```
+
+### Dashboard Upload Route
+```python
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files['receipt']
+    file.save(Path('uploads') / file.filename)
+    return redirect(url_for('index'))
+```
+
+## Next Steps
+
+* Integrate Google Vision or Microsoft OCR for improved accuracy.
+* Link Google Forms to spreadsheets for quick mobile data entry.
+* Generate reports with pandas or Google Data Studio.
+* Consider future integration with QuickBooks for accounting.

--- a/excel_templates/fuel_log_template.csv
+++ b/excel_templates/fuel_log_template.csv
@@ -1,0 +1,1 @@
+Date,Vehicle,Gallons,PricePerGallon,TotalCost,Odometer,JobID,Notes

--- a/excel_templates/quote_template.csv
+++ b/excel_templates/quote_template.csv
@@ -1,0 +1,1 @@
+Item,Description,Quantity,UnitPrice,Total

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,0 +1,22 @@
+"""Minimal Flask dashboard for uploading receipts and viewing costs."""
+from flask import Flask, render_template, request, redirect, url_for
+from pathlib import Path
+
+app = Flask(__name__)
+UPLOAD_DIR = Path('uploads')
+UPLOAD_DIR.mkdir(exist_ok=True)
+
+@app.route('/')
+def index():
+    files = [f.name for f in UPLOAD_DIR.glob('*')]
+    return render_template('index.html', files=files)
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files['receipt']
+    dest = UPLOAD_DIR / file.filename
+    file.save(dest)
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Receipt Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  </head>
+  <body class="p-4">
+    <h1>Receipts</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data" class="mb-3">
+      <input type="file" name="receipt" required>
+      <button class="btn btn-primary" type="submit">Upload</button>
+    </form>
+    <ul>
+    {% for f in files %}
+      <li>{{ f }}</li>
+    {% endfor %}
+    </ul>
+  </body>
+</html>

--- a/src/ocr/job_assigner.py
+++ b/src/ocr/job_assigner.py
@@ -1,0 +1,22 @@
+"""CLI tool to assign job IDs to receipt line items."""
+import csv
+from pathlib import Path
+
+def assign_jobs(csv_path: str):
+    rows = list(csv.DictReader(open(csv_path)))
+    for row in rows:
+        print(f"Item: {row.get('item')} | Cost: {row.get('price')}")
+        row['job_id'] = input('Enter job ID: ')
+    out_path = Path(csv_path).with_name(Path(csv_path).stem + '_tagged.csv')
+    with open(out_path, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f'Saved tagged file to {out_path}')
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) != 2:
+        print('Usage: python job_assigner.py <receipt.csv>')
+    else:
+        assign_jobs(sys.argv[1])

--- a/src/ocr/receipt_ocr.py
+++ b/src/ocr/receipt_ocr.py
@@ -1,0 +1,31 @@
+"""OCR script for receipts using Tesseract.
+Extracts store name, items, prices, and date from a receipt image.
+Outputs JSON file with parsed data.
+"""
+from pathlib import Path
+import json
+
+from PIL import Image
+import pytesseract
+
+def extract_receipt(image_path: str) -> dict:
+    """Extract text from receipt image and return basic structured data."""
+    text = pytesseract.image_to_string(Image.open(image_path))
+    # Placeholder parsing logic; would parse line items here
+    return {"raw_text": text}
+
+
+def main(paths):
+    for img in paths:
+        data = extract_receipt(img)
+        out_path = Path(img).with_suffix('.json')
+        out_path.write_text(json.dumps(data, indent=2))
+        print(f"Written {out_path}")
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python receipt_ocr.py <image1> <image2> ...")
+    else:
+        main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- Add skeleton docs describing a digital ecosystem for receipts, fuel logs, quotes, and dashboard
- Provide OCR scripts and job assignment helper
- Include minimal Flask dashboard and CSV templates for fuel log and quotes

## Testing
- `python -m py_compile src/ocr/receipt_ocr.py src/ocr/job_assigner.py src/dashboard/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5214f750883218bc8df5dff96e1bd